### PR TITLE
Use prefix for snippet

### DIFF
--- a/client/snippets/al.json
+++ b/client/snippets/al.json
@@ -60,7 +60,7 @@
 		]
 	},
 	"Variable: Text":{
-		"prefix": "Text",
+		"prefix": "tText",
 		"body":[
 			"${3:myText}: Text${1:[${2:20}]};$0"
 		]


### PR DESCRIPTION
Hi and thx for a great extension! Recently I've become quite annoyed by the Text snippet which has been disrupting my flow because it's always the top intellisense suggestion. So when declaring a var like: MyList: List of [Text] it gets in the way.

I really think you should consider using prefix for all snippets and I'll gladly submit a PR for that if you'd like.